### PR TITLE
Waiting until the daemon is ready to accept requests resolves the loc…

### DIFF
--- a/payd-data/load_wallet.sh
+++ b/payd-data/load_wallet.sh
@@ -1,7 +1,16 @@
 echo "starting daemon..."
 d="$(date +%s)"
 mkdir "/root/.electrum-sv/$d"
-./electrum-sv daemon -v=debug --enable-node-wallet-api -rpcpassword= -walletnotify="python3 contrib/scripts/jsonrpc_wallet_event.py %s" > "/root/.electrum-sv/$d/daemon_log.txt" 2>&1 &
+./electrum-sv daemon -v=debug --enable-node-wallet-api -rpcpassword= --restapi-password= -walletnotify="python3 contrib/scripts/jsonrpc_wallet_event.py %s" > "/root/.electrum-sv/$d/daemon_log.txt" 2>&1 &
+# We must wait until the daemon has had a chance to startup and write to the lockfile
+status_code=404  # too early
+status_code=$(curl -s -o /dev/null -w "%{http_code}" --request POST --url http://127.0.0.1:9999/v1/rpc/ping --header 'Content-Type: text/plain')
+until [ "$status_code" -eq "200" ];
+do
+  echo "$status_code - waiting for daemon to be ready.."
+  sleep 2
+  status_code=$(curl -s -o /dev/null -w "%{http_code}" --request POST --url http://127.0.0.1:9999/v1/rpc/ping --header 'Content-Type: text/plain')
+done
 
 echo "checking if we need to create a new wallet..."
 file="/root/.electrum-sv/wallets/demo.sqlite"


### PR DESCRIPTION
…kfile issue

- Otherwise attempting to load the wallet immediately after spawning the daemon as a background task results in an empty lockfile. The daemon needs time to write the bind address, port and timestamp.